### PR TITLE
Move to MaybeUninit

### DIFF
--- a/src/controls.rs
+++ b/src/controls.rs
@@ -25,14 +25,17 @@ pub enum AutoExposurePriority {
 impl<'a> DeviceHandle<'a> {
     pub fn scanning_mode(&self) -> Result<ScanningMode> {
         unsafe {
-            let mut mode = std::mem::uninitialized();
-            let err =
-                uvc_get_scanning_mode(self.devh.as_ptr(), &mut mode, uvc_req_code_UVC_GET_CUR)
-                    .into();
+            let mut mode = std::mem::MaybeUninit::uninit();
+            let err = uvc_get_scanning_mode(
+                self.devh.as_ptr(),
+                mode.as_mut_ptr(),
+                uvc_req_code_UVC_GET_CUR,
+            )
+            .into();
             if err != Error::Success {
                 return Err(err);
             }
-            match mode {
+            match mode.assume_init() {
                 0 => Ok(ScanningMode::Interlaced),
                 1 => Ok(ScanningMode::Progressive),
                 _ => Err(Error::Other),
@@ -41,13 +44,17 @@ impl<'a> DeviceHandle<'a> {
     }
     pub fn ae_mode(&self) -> Result<AutoExposureMode> {
         unsafe {
-            let mut mode = std::mem::uninitialized();
-            let err =
-                uvc_get_ae_mode(self.devh.as_ptr(), &mut mode, uvc_req_code_UVC_GET_CUR).into();
+            let mut mode = std::mem::MaybeUninit::uninit();
+            let err = uvc_get_ae_mode(
+                self.devh.as_ptr(),
+                mode.as_mut_ptr(),
+                uvc_req_code_UVC_GET_CUR,
+            )
+            .into();
             if err != Error::Success {
                 return Err(err);
             }
-            match mode {
+            match mode.assume_init() {
                 1 => Ok(AutoExposureMode::Manual),
                 2 => Ok(AutoExposureMode::Auto),
                 4 => Ok(AutoExposureMode::ShutterPriority),
@@ -58,14 +65,17 @@ impl<'a> DeviceHandle<'a> {
     }
     pub fn ae_priority(&self) -> Result<AutoExposurePriority> {
         unsafe {
-            let mut priority = std::mem::uninitialized();
-            let err =
-                uvc_get_ae_priority(self.devh.as_ptr(), &mut priority, uvc_req_code_UVC_GET_CUR)
-                    .into();
+            let mut priority = std::mem::MaybeUninit::uninit();
+            let err = uvc_get_ae_priority(
+                self.devh.as_ptr(),
+                priority.as_mut_ptr(),
+                uvc_req_code_UVC_GET_CUR,
+            )
+            .into();
             if err != Error::Success {
                 return Err(err);
             }
-            match priority {
+            match priority.assume_init() {
                 0 => Ok(AutoExposurePriority::Constant),
                 1 => Ok(AutoExposurePriority::Variable),
                 _ => Err(Error::Other),
@@ -74,55 +84,67 @@ impl<'a> DeviceHandle<'a> {
     }
     pub fn exposure_abs(&self) -> Result<u32> {
         unsafe {
-            let mut time = std::mem::uninitialized();
-            let err = uvc_get_exposure_abs(self.devh.as_ptr(), &mut time, uvc_req_code_UVC_GET_CUR)
-                .into();
-            if err != Error::Success {
-                Err(err)
-            } else {
-                Ok(time)
-            }
-        }
-    }
-    pub fn exposure_rel(&self) -> Result<i8> {
-        unsafe {
-            let mut step = std::mem::uninitialized();
-            let err = uvc_get_exposure_rel(self.devh.as_ptr(), &mut step, uvc_req_code_UVC_GET_CUR)
-                .into();
-            if err != Error::Success {
-                Err(err)
-            } else {
-                Ok(step)
-            }
-        }
-    }
-    pub fn focus_abs(&self) -> Result<u16> {
-        unsafe {
-            let mut focus = std::mem::uninitialized();
-            let err =
-                uvc_get_focus_abs(self.devh.as_ptr(), &mut focus, uvc_req_code_UVC_GET_CUR).into();
-            if err != Error::Success {
-                Err(err)
-            } else {
-                Ok(focus)
-            }
-        }
-    }
-    pub fn focus_rel(&self) -> Result<(i8, u8)> {
-        unsafe {
-            let mut focus_rel = std::mem::uninitialized();
-            let mut speed = std::mem::uninitialized();
-            let err = uvc_get_focus_rel(
+            let mut time = std::mem::MaybeUninit::uninit();
+            let err = uvc_get_exposure_abs(
                 self.devh.as_ptr(),
-                &mut focus_rel,
-                &mut speed,
+                time.as_mut_ptr(),
                 uvc_req_code_UVC_GET_CUR,
             )
             .into();
             if err != Error::Success {
                 Err(err)
             } else {
-                Ok((focus_rel, speed))
+                Ok(time.assume_init())
+            }
+        }
+    }
+    pub fn exposure_rel(&self) -> Result<i8> {
+        unsafe {
+            let mut step = std::mem::MaybeUninit::uninit();
+            let err = uvc_get_exposure_rel(
+                self.devh.as_ptr(),
+                step.as_mut_ptr(),
+                uvc_req_code_UVC_GET_CUR,
+            )
+            .into();
+            if err != Error::Success {
+                Err(err)
+            } else {
+                Ok(step.assume_init())
+            }
+        }
+    }
+    pub fn focus_abs(&self) -> Result<u16> {
+        unsafe {
+            let mut focus = std::mem::MaybeUninit::uninit();
+            let err = uvc_get_focus_abs(
+                self.devh.as_ptr(),
+                focus.as_mut_ptr(),
+                uvc_req_code_UVC_GET_CUR,
+            )
+            .into();
+            if err != Error::Success {
+                Err(err)
+            } else {
+                Ok(focus.assume_init())
+            }
+        }
+    }
+    pub fn focus_rel(&self) -> Result<(i8, u8)> {
+        unsafe {
+            let mut focus_rel = std::mem::MaybeUninit::uninit();
+            let mut speed = std::mem::MaybeUninit::uninit();
+            let err = uvc_get_focus_rel(
+                self.devh.as_ptr(),
+                focus_rel.as_mut_ptr(),
+                speed.as_mut_ptr(),
+                uvc_req_code_UVC_GET_CUR,
+            )
+            .into();
+            if err != Error::Success {
+                Err(err)
+            } else {
+                Ok((focus_rel.assume_init(), speed.assume_init()))
             }
         }
     }

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -106,13 +106,13 @@ impl Frame {
     /// Clones a frame
     pub fn duplicate(&self) -> Result<Frame> {
         unsafe {
-            let new_frame = std::mem::uninitialized();
+            let mut new_frame = Frame::from_raw(uvc_allocate_frame(0));
 
-            let err = uvc_duplicate_frame(self.frame.as_ptr(), new_frame).into();
+            let err = uvc_duplicate_frame(self.frame.as_ptr(), new_frame.frame.as_mut()).into();
             if err != Error::Success {
                 return Err(err);
             }
-            Ok(Frame::from_raw(new_frame))
+            Ok(new_frame)
         }
     }
 }


### PR DESCRIPTION
Replaces the usages of `std::mem::uninitialized()` with `std::mem::MaybeUninit`.