### PR TITLE
Upgrade bindgen dependency

### DIFF
--- a/uvc-sys/Cargo.toml
+++ b/uvc-sys/Cargo.toml
@@ -11,4 +11,4 @@ categories = ["external-ffi-bindings", "multimedia::video"]
 edition = "2018"
 
 [build-dependencies]
-bindgen = "^0.49.0"
+bindgen = "0.51.0"


### PR DESCRIPTION
Bindgen 0.49 generated broken bindings for libuvc 0.0.6 with the following error:
```
error[E0277]: `__mbstate_t__bindgen_ty_1` doesn't implement `std::fmt::Debug`
   --> /home/patrick/build/libuvc-rs/target/debug/build/uvc-sys-83382debf0f6edf9/out/bindings.rs:224:5
    |
224 |     pub __value: __mbstate_t__bindgen_ty_1,
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `__mbstate_t__bindgen_ty_1` cannot be formatted using `{:?}`
    |
    = help: the trait `std::fmt::Debug` is not implemented for `__mbstate_t__bindgen_ty_1`
    = note: add `#[derive(Debug)]` or manually implement `std::fmt::Debug`
    = note: required because of the requirements on the impl of `std::fmt::Debug` for `&__mbstate_t__bindgen_ty_1`
    = note: required for the cast to the object type `dyn std::fmt::Debug`

error[E0277]: `uvc_format_desc__bindgen_ty_1` doesn't implement `std::fmt::Debug`
    --> /home/patrick/build/libuvc-rs/target/debug/build/uvc-sys-83382debf0f6edf9/out/bindings.rs:1781:5
     |
1781 |     pub __bindgen_anon_1: uvc_format_desc__bindgen_ty_1,
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `uvc_format_desc__bindgen_ty_1` cannot be formatted using `{:?}`
     |
     = help: the trait `std::fmt::Debug` is not implemented for `uvc_format_desc__bindgen_ty_1`
     = note: add `#[derive(Debug)]` or manually implement `std::fmt::Debug`
     = note: required because of the requirements on the impl of `std::fmt::Debug` for `&uvc_format_desc__bindgen_ty_1`
     = note: required for the cast to the object type `dyn std::fmt::Debug`

error[E0277]: `uvc_format_desc__bindgen_ty_2` doesn't implement `std::fmt::Debug`
    --> /home/patrick/build/libuvc-rs/target/debug/build/uvc-sys-83382debf0f6edf9/out/bindings.rs:1782:5
     |
1782 |     pub __bindgen_anon_2: uvc_format_desc__bindgen_ty_2,
     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `uvc_format_desc__bindgen_ty_2` cannot be formatted using `{:?}`
     |
     = help: the trait `std::fmt::Debug` is not implemented for `uvc_format_desc__bindgen_ty_2`
     = note: add `#[derive(Debug)]` or manually implement `std::fmt::Debug`
     = note: required because of the requirements on the impl of `std::fmt::Debug` for `&uvc_format_desc__bindgen_ty_2`
     = note: required for the cast to the object type `dyn std::fmt::Debug`

error: aborting due to 3 previous errors

For more information about this error, try `rustc --explain E0277`.
error: could not compile `uvc-sys`.
```

Upgrading to 0.51 in `uvc-sys` fixed the issue for me.