### PR TITLE
build jpeg statically

### DIFF
--- a/uvc-src/Cargo.toml
+++ b/uvc-src/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/mulimoen/libuvc-rs"
 description = "Vendored version of libuvc"
 
 [dependencies]
+mozjpeg-sys = "0.10.4"
 
 [build-dependencies]
 cmake = "0.1.44"

--- a/uvc-src/Cargo.toml
+++ b/uvc-src/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/mulimoen/libuvc-rs"
 description = "Vendored version of libuvc"
 
 [dependencies]
-mozjpeg-sys = "0.10.4"
+mozjpeg-sys = { version = "0.10.4", default-features = false }
 
 [build-dependencies]
 cmake = "0.1.44"

--- a/uvc-src/build.rs
+++ b/uvc-src/build.rs
@@ -8,6 +8,7 @@ fn main() {
     let jpeg_version = std::env::var("DEP_JPEG_LIB_VERSION").unwrap();
     let jpeg_lib_path = format!("{}/..", jpeg_include.to_str().unwrap(),);
     let jpeg_lib = format!("mozjpeg{}", jpeg_version);
+    let jpeg_include = jpeg_paths.next().unwrap();
 
     let dst = cmake::Config::new("source")
         .define("ENABLE_UVC_DEBUGGING", "OFF")

--- a/uvc-src/build.rs
+++ b/uvc-src/build.rs
@@ -8,7 +8,7 @@ fn main() {
     let jpeg_version = std::env::var("DEP_JPEG_LIB_VERSION").unwrap();
     let jpeg_lib_path = format!("{}/..", jpeg_include.to_str().unwrap(),);
     let jpeg_lib = format!("mozjpeg{}", jpeg_version);
-    let jpeg_include = jpeg_paths.next().unwrap();
+    let jpeg_include2 = jpeg_paths.next().unwrap();
 
     let dst = cmake::Config::new("source")
         .define("ENABLE_UVC_DEBUGGING", "OFF")
@@ -16,8 +16,22 @@ fn main() {
         .define("BUILD_EXAMPLE", "OFF")
         .define("JPEG_LIBRARY_RELEASE:PATH", &jpeg_lib_path)
         .define("JPEG_LIBRARY:PATH", &jpeg_lib_path)
-        .define("JPEG_INCLUDE_DIRS:PATH", &jpeg_include)
-        .define("JPEG_INCLUDE_DIR:PATH", &jpeg_include)
+        .define(
+            "JPEG_INCLUDE_DIRS:PATH",
+            format!(
+                "{};{}",
+                &jpeg_include.to_str().unwrap(),
+                &jpeg_include2.to_str().unwrap()
+            ),
+        )
+        .define(
+            "JPEG_INCLUDE_DIR:PATH",
+            format!(
+                "{};{}",
+                &jpeg_include.to_str().unwrap(),
+                &jpeg_include2.to_str().unwrap()
+            ),
+        )
         .build();
 
     println!("cargo:rustc-link-lib=static={}", jpeg_lib);

--- a/uvc-src/build.rs
+++ b/uvc-src/build.rs
@@ -1,8 +1,5 @@
 fn main() {
     println!("cargo:rustc-link-lib=usb-1.0");
-    for env in std::env::vars() {
-        println!("{:?}", env);
-    }
 
     let jpeg_include = std::env::var_os("DEP_JPEG_INCLUDE").unwrap();
     let mut jpeg_paths = std::env::split_paths(&jpeg_include);
@@ -16,8 +13,8 @@ fn main() {
         .define("ENABLE_UVC_DEBUGGING", "OFF")
         .define("CMAKE_BUILD_TARGET", "Static")
         .define("BUILD_EXAMPLE", "OFF")
-        .define("DJPEG_LIBRARY_PATH:PATH", &jpeg_lib_path)
-        .define("DJPEG_INCLUDE_DIR:PATH", &jpeg_include)
+        .define("JPEG_LIBRARY_RELEASE:PATH", &jpeg_lib_path)
+        .define("JPEG_INCLUDE_DIRS:PATH", &jpeg_include)
         .build();
 
     println!("cargo:rustc-link-lib=static={}", jpeg_lib);

--- a/uvc-src/build.rs
+++ b/uvc-src/build.rs
@@ -14,7 +14,9 @@ fn main() {
         .define("CMAKE_BUILD_TARGET", "Static")
         .define("BUILD_EXAMPLE", "OFF")
         .define("JPEG_LIBRARY_RELEASE:PATH", &jpeg_lib_path)
+        .define("JPEG_LIBRARY:PATH", &jpeg_lib_path)
         .define("JPEG_INCLUDE_DIRS:PATH", &jpeg_include)
+        .define("JPEG_INCLUDE_DIR:PATH", &jpeg_include)
         .build();
 
     println!("cargo:rustc-link-lib=static={}", jpeg_lib);


### PR DESCRIPTION
Linking to a static build of libjpeg in the vendored version

Fixes #6