### PR TITLE
-add library include search path under freebsd

### DIFF
--- a/uvc-sys/build.rs
+++ b/uvc-sys/build.rs
@@ -6,8 +6,13 @@ use std::path::PathBuf;
 fn main() {
     println!("cargo:rustc-link-lib=uvc");
 
-    let bindings = bindgen::Builder::default()
-        .header("wrapper.h")
+    let mut builder = bindgen::Builder::default();
+
+    if cfg!(target_os = "freebsd"){
+        builder = builder.clang_arg("-I/usr/local/include");
+    }
+
+    let bindings = builder.header("wrapper.h")
         .whitelist_function("uvc_.*")
         .whitelist_type("uvc_.*")
         .generate()


### PR DESCRIPTION
Hi!

I had problem under freebsd while building your wrapper crate.

The bindgen cannot find the required header file, I modified the build script and add header search path explicitly when building on freebsd.

Regards,
Ferenc 