### PR TITLE
Bump bindgen version

### DIFF
--- a/uvc-sys/Cargo.toml
+++ b/uvc-sys/Cargo.toml
@@ -17,4 +17,4 @@ vendor = ["uvc-src"]
 uvc-src = { path = "../uvc-src", version = "0.2.0", optional = true, features = ["jpeg"] }
 
 [build-dependencies]
-bindgen = "0.54.0"
+bindgen = "0.55.1"


### PR DESCRIPTION
Bump the bindgen version in order to resolve conflicts with libraries that have already updated