### PR TITLE
update glium to 0.29

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 uvc-sys = { path = "uvc-sys", version = "0.1.4" }
 
 [dev-dependencies]
-glium = "0.27.0"
+glium = "0.29.0"
 
 [features]
 vendor = ["uvc-sys/vendor"]


### PR DESCRIPTION
This pulls in glutin = "0.26" which in turn brings winit = "0.26".
The new winit update adds support for macOS 11.x, which means the
mirror example is now working.

Signed-off-by: Christopher N. Hesse <raymanfx@gmail.com>