### PR TITLE
Bindgen 0.56.0

### DIFF
--- a/uvc-sys/Cargo.toml
+++ b/uvc-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uvc-sys"
 description = "Raw wrapper of libuvc"
-version = "0.1.5"
+version = "0.1.6"
 authors = ["Magnus Ulimoen <flymagnus@gmail.com>"]
 links = "uvc"
 build = "build.rs"

--- a/uvc-sys/Cargo.toml
+++ b/uvc-sys/Cargo.toml
@@ -17,4 +17,4 @@ vendor = ["uvc-src"]
 uvc-src = { path = "../uvc-src", version = "0.2.0", optional = true, features = ["jpeg"] }
 
 [build-dependencies]
-bindgen = "0.55.1"
+bindgen = "0.56.0"


### PR DESCRIPTION
The usual stuff - in a project of mine, another dependency now uses `bindgen = "0.56.0"`, so there's conflicts.
Could we get a new `crates.io` release with all the latest commits?