### PR TITLE
Switch Error to a newtype instead of enum

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 uvc-sys = { path = "uvc-sys", version = "0.2.0" }
 
 [dev-dependencies]
-glium = "0.29.0"
+glium = "0.32"
 
 [features]
 vendor = ["uvc-sys/vendor"]

--- a/examples/mirror.rs
+++ b/examples/mirror.rs
@@ -20,10 +20,7 @@ fn frame_to_raw_image(
     Ok(image)
 }
 
-fn callback_frame_to_image(
-    frame: &Frame,
-    data: &mut Arc<Mutex<Option<glium::texture::RawImage2d<u8>>>>,
-) {
+fn callback_frame_to_image(frame: &Frame, data: &Mutex<Option<glium::texture::RawImage2d<u8>>>) {
     let image = frame_to_raw_image(frame);
     match image {
         Err(x) => println!("{:#?}", x),
@@ -84,8 +81,9 @@ fn main() {
         );
 
     let frame = Arc::new(Mutex::new(None));
+    let frame2 = frame.clone();
     let _stream = streamh
-        .start_stream(callback_frame_to_image, frame.clone())
+        .start_stream(move |frame| callback_frame_to_image(frame, &frame2))
         .unwrap();
 
     use glium::glutin;

--- a/src/context.rs
+++ b/src/context.rs
@@ -31,14 +31,11 @@ impl<'a> Context<'a> {
         unsafe {
             let mut ctx = std::mem::MaybeUninit::<*mut uvc_context>::uninit();
             let err = uvc_init(ctx.as_mut_ptr(), std::ptr::null_mut()).into();
-            if err == Error::Success {
-                Ok(Context {
-                    ctx: NonNull::new(ctx.assume_init()).unwrap(),
-                    _ctx: PhantomData,
-                })
-            } else {
-                Err(err)
-            }
+            Error::cvt(err)?;
+            Ok(Context {
+                ctx: NonNull::new(ctx.assume_init()).unwrap(),
+                _ctx: PhantomData,
+            })
         }
     }
 
@@ -47,9 +44,7 @@ impl<'a> Context<'a> {
         unsafe {
             let mut list = std::mem::MaybeUninit::<*mut *mut uvc_device>::uninit();
             let err = uvc_get_device_list(self.ctx.as_ptr(), list.as_mut_ptr()).into();
-            if err != Error::Success {
-                return Err(err);
-            }
+            Error::cvt(err)?;
 
             Ok(DeviceList::new(NonNull::new(list.assume_init()).unwrap()))
         }
@@ -74,9 +69,7 @@ impl<'a> Context<'a> {
                 cstr.map_or(std::ptr::null(), |v| v.as_ptr()),
             )
             .into();
-            if err != Error::Success {
-                return Err(err);
-            }
+            Error::cvt(err)?;
             Ok(Device::from_raw(device.assume_init()))
         }
     }

--- a/src/controls.rs
+++ b/src/controls.rs
@@ -32,13 +32,11 @@ impl<'a> DeviceHandle<'a> {
                 uvc_req_code_UVC_GET_CUR,
             )
             .into();
-            if err != Error::Success {
-                return Err(err);
-            }
+            Error::cvt(err)?;
             match mode.assume_init() {
                 0 => Ok(ScanningMode::Interlaced),
                 1 => Ok(ScanningMode::Progressive),
-                _ => Err(Error::Other),
+                _ => Err(Error::OTHER),
             }
         }
     }
@@ -51,15 +49,13 @@ impl<'a> DeviceHandle<'a> {
                 uvc_req_code_UVC_GET_CUR,
             )
             .into();
-            if err != Error::Success {
-                return Err(err);
-            }
+            Error::cvt(err)?;
             match mode.assume_init() {
                 1 => Ok(AutoExposureMode::Manual),
                 2 => Ok(AutoExposureMode::Auto),
                 4 => Ok(AutoExposureMode::ShutterPriority),
                 8 => Ok(AutoExposureMode::AperturePriority),
-                _ => Err(Error::Other),
+                _ => Err(Error::OTHER),
             }
         }
     }
@@ -72,13 +68,11 @@ impl<'a> DeviceHandle<'a> {
                 uvc_req_code_UVC_GET_CUR,
             )
             .into();
-            if err != Error::Success {
-                return Err(err);
-            }
+            Error::cvt(err)?;
             match priority.assume_init() {
                 0 => Ok(AutoExposurePriority::Constant),
                 1 => Ok(AutoExposurePriority::Variable),
-                _ => Err(Error::Other),
+                _ => Err(Error::OTHER),
             }
         }
     }
@@ -91,11 +85,8 @@ impl<'a> DeviceHandle<'a> {
                 uvc_req_code_UVC_GET_CUR,
             )
             .into();
-            if err == Error::Success {
-                Ok(time.assume_init())
-            } else {
-                Err(err)
-            }
+            Error::cvt(err)?;
+            Ok(time.assume_init())
         }
     }
     pub fn exposure_rel(&self) -> Result<i8> {
@@ -107,11 +98,8 @@ impl<'a> DeviceHandle<'a> {
                 uvc_req_code_UVC_GET_CUR,
             )
             .into();
-            if err == Error::Success {
-                Ok(step.assume_init())
-            } else {
-                Err(err)
-            }
+            Error::cvt(err)?;
+            Ok(step.assume_init())
         }
     }
     pub fn focus_abs(&self) -> Result<u16> {
@@ -123,11 +111,8 @@ impl<'a> DeviceHandle<'a> {
                 uvc_req_code_UVC_GET_CUR,
             )
             .into();
-            if err == Error::Success {
-                Ok(focus.assume_init())
-            } else {
-                Err(err)
-            }
+            Error::cvt(err)?;
+            Ok(focus.assume_init())
         }
     }
     pub fn focus_rel(&self) -> Result<(i8, u8)> {
@@ -141,11 +126,8 @@ impl<'a> DeviceHandle<'a> {
                 uvc_req_code_UVC_GET_CUR,
             )
             .into();
-            if err == Error::Success {
-                Ok((focus_rel.assume_init(), speed.assume_init()))
-            } else {
-                Err(err)
-            }
+            Error::cvt(err)?;
+            Ok((focus_rel.assume_init(), speed.assume_init()))
         }
     }
 }

--- a/src/device.rs
+++ b/src/device.rs
@@ -78,13 +78,11 @@ impl<'a> Device<'a> {
         unsafe {
             let mut devh = std::mem::MaybeUninit::uninit();
             let err = uvc_open(self.dev.as_ptr(), devh.as_mut_ptr()).into();
-            match err {
-                Error::Success => Ok(DeviceHandle {
-                    devh: NonNull::new(devh.assume_init()).unwrap(),
-                    _devh: PhantomData,
-                }),
-                err => Err(err),
-            }
+            Error::cvt(err)?;
+            Ok(DeviceHandle {
+                devh: NonNull::new(devh.assume_init()).unwrap(),
+                _devh: PhantomData,
+            })
         }
     }
     /// Get the description of a device
@@ -92,9 +90,7 @@ impl<'a> Device<'a> {
         unsafe {
             let mut desc = std::mem::MaybeUninit::uninit();
             let err = uvc_get_device_descriptor(self.dev.as_ptr(), desc.as_mut_ptr()).into();
-            if err != Error::Success {
-                return Err(err);
-            }
+            Error::cvt(err)?;
 
             let desc = desc.assume_init();
 
@@ -236,14 +232,11 @@ impl<'a, 'b> DeviceHandle<'a> {
                 fps as i32,
             )
             .into();
-            if err == Error::Success {
-                Ok(StreamHandle {
-                    handle: handle.assume_init(),
-                    devh: self,
-                })
-            } else {
-                Err(err)
-            }
+            Error::cvt(err)?;
+            Ok(StreamHandle {
+                handle: handle.assume_init(),
+                devh: self,
+            })
         }
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,85 +1,69 @@
 use std::ffi::CStr;
 use std::fmt;
+use std::num::NonZeroI32;
 
 /// Result type of functions in this crate
 pub type Result<T> = std::result::Result<T, Error>;
 
 /// Error codes from `libusb`
-#[derive(Debug, PartialEq, Copy, Clone)]
-pub enum Error {
-    Success,
-    Access,
-    Busy,
-    CallbackExists,
-    Interrupted,
-    InvalidDevice,
-    InvalidMode,
-    InvalidParam,
-    IO,
-    NotFound,
-    NotSupported,
-    NoDevice,
-    NoMem,
-    Other,
-    Overflow,
-    Pipe,
-    Timeout,
-    Unknown(uvc_sys::uvc_error_t),
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+pub struct Error(NonZeroI32);
+
+const fn make_err(x: uvc_sys::uvc_error_t) -> Error {
+    Error(unsafe { NonZeroI32::new_unchecked(x) })
+}
+impl Error {
+    pub const ACCESS: Self = make_err(uvc_sys::uvc_error_UVC_ERROR_ACCESS);
+    pub const BUSY: Self = make_err(uvc_sys::uvc_error_UVC_ERROR_BUSY);
+    pub const CALLBACK_EXISTS: Self = make_err(uvc_sys::uvc_error_UVC_ERROR_CALLBACK_EXISTS);
+    pub const INTERRUPTED: Self = make_err(uvc_sys::uvc_error_UVC_ERROR_INTERRUPTED);
+    pub const INVALID_DEVICE: Self = make_err(uvc_sys::uvc_error_UVC_ERROR_INVALID_DEVICE);
+    pub const INVALID_MODE: Self = make_err(uvc_sys::uvc_error_UVC_ERROR_INVALID_MODE);
+    pub const INVALID_PARAM: Self = make_err(uvc_sys::uvc_error_UVC_ERROR_INVALID_PARAM);
+    pub const IO: Self = make_err(uvc_sys::uvc_error_UVC_ERROR_IO);
+    pub const NOT_FOUND: Self = make_err(uvc_sys::uvc_error_UVC_ERROR_NOT_FOUND);
+    pub const NOT_SUPPORTED: Self = make_err(uvc_sys::uvc_error_UVC_ERROR_NOT_SUPPORTED);
+    pub const NO_DEVICE: Self = make_err(uvc_sys::uvc_error_UVC_ERROR_NO_DEVICE);
+    pub const NO_MEM: Self = make_err(uvc_sys::uvc_error_UVC_ERROR_NO_MEM);
+    pub const OTHER: Self = make_err(uvc_sys::uvc_error_UVC_ERROR_OTHER);
+    pub const OVERFLOW: Self = make_err(uvc_sys::uvc_error_UVC_ERROR_OVERFLOW);
+    pub const PIPE: Self = make_err(uvc_sys::uvc_error_UVC_ERROR_PIPE);
+    pub const TIMEOUT: Self = make_err(uvc_sys::uvc_error_UVC_ERROR_TIMEOUT);
 }
 
-impl From<uvc_sys::uvc_error_t> for Error {
-    fn from(code: uvc_sys::uvc_error_t) -> Self {
-        match code {
-            uvc_sys::uvc_error_UVC_SUCCESS => Error::Success,
-            uvc_sys::uvc_error_UVC_ERROR_ACCESS => Error::Access,
-            uvc_sys::uvc_error_UVC_ERROR_BUSY => Error::Busy,
-            uvc_sys::uvc_error_UVC_ERROR_CALLBACK_EXISTS => Error::CallbackExists,
-            uvc_sys::uvc_error_UVC_ERROR_INTERRUPTED => Error::Interrupted,
-            uvc_sys::uvc_error_UVC_ERROR_INVALID_DEVICE => Error::InvalidDevice,
-            uvc_sys::uvc_error_UVC_ERROR_INVALID_MODE => Error::InvalidMode,
-            uvc_sys::uvc_error_UVC_ERROR_INVALID_PARAM => Error::InvalidParam,
-            uvc_sys::uvc_error_UVC_ERROR_IO => Error::IO,
-            uvc_sys::uvc_error_UVC_ERROR_NOT_FOUND => Error::NotFound,
-            uvc_sys::uvc_error_UVC_ERROR_NOT_SUPPORTED => Error::NotSupported,
-            uvc_sys::uvc_error_UVC_ERROR_NO_DEVICE => Error::NoDevice,
-            uvc_sys::uvc_error_UVC_ERROR_NO_MEM => Error::NoMem,
-            uvc_sys::uvc_error_UVC_ERROR_OTHER => Error::Other,
-            uvc_sys::uvc_error_UVC_ERROR_OVERFLOW => Error::Overflow,
-            uvc_sys::uvc_error_UVC_ERROR_PIPE => Error::Pipe,
-            uvc_sys::uvc_error_UVC_ERROR_TIMEOUT => Error::Timeout,
-            x => Error::Unknown(x),
-        }
-    }
-}
+// impl From<uvc_sys::uvc_error_t> for Error {
+//     fn from(code: uvc_sys::uvc_error_t) -> Self {
+//         Error(code)
+//     }
+// }
 
 impl Into<uvc_sys::uvc_error_t> for Error {
     fn into(self) -> uvc_sys::uvc_error_t {
-        match self {
-            Error::Success => uvc_sys::uvc_error_UVC_SUCCESS,
-            Error::Access => uvc_sys::uvc_error_UVC_ERROR_ACCESS,
-            Error::Busy => uvc_sys::uvc_error_UVC_ERROR_BUSY,
-            Error::CallbackExists => uvc_sys::uvc_error_UVC_ERROR_CALLBACK_EXISTS,
-            Error::Interrupted => uvc_sys::uvc_error_UVC_ERROR_INTERRUPTED,
-            Error::InvalidDevice => uvc_sys::uvc_error_UVC_ERROR_INVALID_DEVICE,
-            Error::InvalidMode => uvc_sys::uvc_error_UVC_ERROR_INVALID_MODE,
-            Error::InvalidParam => uvc_sys::uvc_error_UVC_ERROR_INVALID_PARAM,
-            Error::IO => uvc_sys::uvc_error_UVC_ERROR_IO,
-            Error::NotFound => uvc_sys::uvc_error_UVC_ERROR_NOT_FOUND,
-            Error::NotSupported => uvc_sys::uvc_error_UVC_ERROR_NOT_SUPPORTED,
-            Error::NoDevice => uvc_sys::uvc_error_UVC_ERROR_NO_DEVICE,
-            Error::NoMem => uvc_sys::uvc_error_UVC_ERROR_NO_MEM,
-            Error::Other => uvc_sys::uvc_error_UVC_ERROR_OTHER,
-            Error::Overflow => uvc_sys::uvc_error_UVC_ERROR_OVERFLOW,
-            Error::Pipe => uvc_sys::uvc_error_UVC_ERROR_PIPE,
-            Error::Timeout => uvc_sys::uvc_error_UVC_ERROR_TIMEOUT,
-            Error::Unknown(x) => x,
+        self.0.get()
+    }
+}
+
+impl Error {
+    pub const fn from_code(x: i32) -> Option<Self> {
+        match NonZeroI32::new(x) {
+            Some(e) => Some(Self(e)),
+            None => None,
+        }
+    }
+    pub const fn code(self) -> i32 {
+        self.0.get()
+    }
+    pub(crate) fn cvt(x: i32) -> Result<()> {
+        match Self::from_code(x) {
+            None => Ok(()),
+            Some(e) => Err(e),
         }
     }
 }
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let strerror = unsafe { uvc_sys::uvc_strerror((*self).into()) };
+        let strerror = unsafe { uvc_sys::uvc_strerror(self.0.get()) };
         if strerror.is_null() {
             return write!(f, "Unknown error");
         }
@@ -87,8 +71,12 @@ impl fmt::Display for Error {
         write!(f, "{}", strerr)
     }
 }
-impl std::error::Error for Error {
-    fn cause(&self) -> Option<&dyn std::error::Error> {
-        None
+impl std::error::Error for Error {}
+
+fn _test_matching() {
+    match Error::ACCESS {
+        Error::ACCESS => {}
+        Error::BUSY => {}
+        _ => {}
     }
 }

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -45,11 +45,8 @@ impl Frame {
         }
         .into();
 
-        if err == Error::Success {
-            Ok(new_frame)
-        } else {
-            Err(err)
-        }
+        Error::cvt(err)?;
+        Ok(new_frame)
     }
 
     /// Convert to bgr format
@@ -66,11 +63,8 @@ impl Frame {
         }
         .into();
 
-        if err == Error::Success {
-            Ok(new_frame)
-        } else {
-            Err(err)
-        }
+        Error::cvt(err)?;
+        Ok(new_frame)
     }
 
     /// Get the raw image data
@@ -114,9 +108,7 @@ impl Frame {
             let mut new_frame = Frame::from_raw(uvc_allocate_frame(0));
 
             let err = uvc_duplicate_frame(self.frame.as_ptr(), new_frame.frame.as_mut()).into();
-            if err != Error::Success {
-                return Err(err);
-            }
+            Error::cvt(err)?;
             Ok(new_frame)
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,13 +44,11 @@
   let counter = Arc::new(AtomicUsize::new(0));
 
   // Get a stream, calling the closure as callback for every frame
+  let count = counter.clone();
   let stream = streamh
-      .start_stream(
-          |_frame, count| {
-              count.fetch_add(1, Ordering::SeqCst);
-          },
-          counter.clone(),
-      ).expect("Could not start stream");
+      .start_stream(|_frame| {
+          count.fetch_add(1, Ordering::SeqCst);
+      }).expect("Could not start stream");
 
   // Wait 10 seconds
   std::thread::sleep(Duration::new(10, 0));

--- a/src/streaming.rs
+++ b/src/streaming.rs
@@ -15,43 +15,36 @@ pub struct StreamHandle<'a> {
     pub(crate) devh: &'a DeviceHandle<'a>,
 }
 
-struct Vtable<U> {
-    func: Box<dyn Fn(&Frame, &mut U)>,
-    data: U,
-}
-
-unsafe impl<'a, U: Send + Sync> Send for ActiveStream<'a, U> {}
-unsafe impl<'a, U: Send + Sync> Sync for ActiveStream<'a, U> {}
+unsafe impl<'a> Send for ActiveStream<'a> {}
+unsafe impl<'a> Sync for ActiveStream<'a> {}
 #[derive(Debug)]
 /// Active stream
 ///
 /// Dropping this stream will stop the stream
-pub struct ActiveStream<'a, U: Send + Sync> {
+pub struct ActiveStream<'a> {
     devh: &'a crate::DeviceHandle<'a>,
-    #[allow(unused)]
-    vtable: *mut Vtable<U>,
+    callback: *mut dyn FnMut(&Frame),
 }
 
-impl<'a, U: Send + Sync> ActiveStream<'a, U> {
+impl ActiveStream<'_> {
     /// Stop the stream
     pub fn stop(self) {
         // Taking ownership of the stream, which drops it
     }
 }
 
-impl<'a, U: Send + Sync> Drop for ActiveStream<'a, U> {
+impl Drop for ActiveStream<'_> {
     fn drop(&mut self) {
         unsafe {
             uvc_stop_streaming(self.devh.devh.as_ptr());
-            let _vtable = Box::from_raw(self.vtable);
+            drop(Box::from_raw(self.callback));
         }
     }
 }
 
-unsafe extern "C" fn trampoline<F, U>(frame: *mut uvc_frame, userdata: *mut c_void)
+unsafe extern "C" fn trampoline<F>(frame: *mut uvc_frame, userdata: *mut c_void)
 where
-    F: 'static + Send + Sync + Fn(&Frame, &mut U),
-    U: 'static + Send + Sync,
+    F: FnMut(&Frame) + Send + 'static,
 {
     let panic = std::panic::catch_unwind(|| {
         if frame.is_null() {
@@ -63,12 +56,9 @@ where
             panic!("Userdata is null");
         }
 
-        let vtable = userdata as *mut Vtable<U>;
+        let func = &mut *(userdata as *mut F);
 
-        let func = &(*vtable).func;
-        let data = &mut (*vtable).data;
-
-        func(&frame, data);
+        func(&frame);
     });
 
     if panic.is_err() {
@@ -81,31 +71,25 @@ impl<'a> StreamHandle<'a> {
     /// Begin a stream, use the callback to save the frames
     ///
     /// This function is non-blocking
-    pub fn start_stream<F, U>(&'a mut self, cb: F, user_data: U) -> Result<ActiveStream<'a, U>>
+    pub fn start_stream<F>(&'a mut self, cb: F) -> Result<ActiveStream<'a>>
     where
-        F: 'static + Send + Sync + Fn(&Frame, &mut U),
-        U: 'static + Send + Sync,
+        F: FnMut(&Frame) + Send + 'static,
     {
-        let tuple = Box::new(Vtable::<U> {
-            func: Box::new(cb),
-            data: user_data,
-        });
-
-        let tuple = Box::into_raw(tuple);
+        let func = Box::into_raw(Box::new(cb));
 
         unsafe {
             let err = uvc_start_streaming(
                 self.devh.devh.as_ptr(),
                 &mut self.handle,
-                Some(trampoline::<F, U>),
-                tuple as *mut c_void,
+                Some(trampoline::<F>),
+                func as *mut c_void,
                 0,
             )
             .into();
             if err == Error::Success {
                 Ok(ActiveStream {
                     devh: self.devh,
-                    vtable: tuple,
+                    callback: func,
                 })
             } else {
                 Err(err)

--- a/src/streaming.rs
+++ b/src/streaming.rs
@@ -86,14 +86,11 @@ impl<'a> StreamHandle<'a> {
                 0,
             )
             .into();
-            if err == Error::Success {
-                Ok(ActiveStream {
-                    devh: self.devh,
-                    callback: func,
-                })
-            } else {
-                Err(err)
-            }
+            Error::cvt(err)?;
+            Ok(ActiveStream {
+                devh: self.devh,
+                callback: func,
+            })
         }
     }
 }


### PR DESCRIPTION
Based off #28. This shrinks the size of the type a bit, and makes it easier to represent unknown error codes.
