### PR TITLE
latest libuvc upstream, latest bindgen, and allow compiling libuvc with UVC_DEBUGGING via feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ glium = "0.29.0"
 
 [features]
 vendor = ["uvc-sys/vendor"]
+uvc_debugging = ["uvc-sys/uvc_debugging"]
 
 [workspace]
 members = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
 name = "uvc"
 description = "Safe and ergonomic wrapper around libuvc, allowing capture of webcam streams"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Magnus Ulimoen <flymagnus@gmail.com>"]
 license = "MIT"
 repository = "https://github.com/mulimoen/libuvc-rs.git"
 categories = ["api-bindings", "multimedia::video"]
 keywords = ["webcam", "capture", "camera"]
 readme = "README.md"
-edition = "2018"
+edition = "2021"
 
 [dependencies]
-uvc-sys = { path = "uvc-sys", version = "0.2.1" }
+uvc-sys = { path = "uvc-sys", version = "0.3.0" }
 
 [dev-dependencies]
 glium = "0.29.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uvc"
 description = "Safe and ergonomic wrapper around libuvc, allowing capture of webcam streams"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Magnus Ulimoen <flymagnus@gmail.com>"]
 license = "MIT"
 repository = "https://github.com/mulimoen/libuvc-rs.git"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-uvc-sys = { path = "uvc-sys", version = "0.2.0" }
+uvc-sys = { path = "uvc-sys", version = "0.2.1" }
 
 [dev-dependencies]
 glium = "0.29.0"

--- a/uvc-src/Cargo.toml
+++ b/uvc-src/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "uvc-src"
-version = "0.2.2"
+version = "0.3.0"
 authors = ["Magnus Ulimoen <flymagnus@gmail.com>"]
-edition = "2018"
+edition = "2021"
 license-file = "source/LICENSE.txt"
 build = "build.rs"
 repository = "https://github.com/mulimoen/libuvc-rs"

--- a/uvc-src/Cargo.toml
+++ b/uvc-src/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uvc-src"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Magnus Ulimoen <flymagnus@gmail.com>"]
 edition = "2018"
 license-file = "source/LICENSE.txt"

--- a/uvc-src/Cargo.toml
+++ b/uvc-src/Cargo.toml
@@ -11,6 +11,7 @@ links = "uvcsrc"
 
 [features]
 jpeg = ["mozjpeg-sys"]
+uvc_debugging = []
 
 [dependencies]
 mozjpeg-sys = { version = "0.10.4", default-features = false, optional = true }

--- a/uvc-src/build.rs
+++ b/uvc-src/build.rs
@@ -23,7 +23,6 @@ fn main() {
     builder.file("source/src/stream.c");
     builder.file("source/src/misc.c");
 
-
     let builddir: std::path::PathBuf = std::env::var_os("OUT_DIR").unwrap().into();
     let includedir = builddir.join("include");
     {

--- a/uvc-src/build.rs
+++ b/uvc-src/build.rs
@@ -23,6 +23,7 @@ fn main() {
     builder.file("source/src/stream.c");
     builder.file("source/src/misc.c");
 
+
     let builddir: std::path::PathBuf = std::env::var_os("OUT_DIR").unwrap().into();
     let includedir = builddir.join("include");
     {
@@ -40,12 +41,18 @@ fn main() {
 #define LIBUVC_VERSION_INT (({major} << 16) | ({minor} << 8) | ({patch}))
 #define LIBUVC_VERSION_GTE(major, minor, patch) (LIB_UVC_VERSION_INT >= (((major) << 16) | ((minor) << 8) | (patch))
 #define LIBUVC_HAS_JPEG {has_jpeg}
+{uvc_debug}
 #endif
 "#,
                 major = VERSION.major,
                 minor = VERSION.minor,
                 patch = VERSION.patch,
                 has_jpeg = std::env::var_os("CARGO_FEATURE_JPEG").is_some() as u8,
+                uvc_debug = if cfg!(feature = "uvc_debugging") {
+                    "#define UVC_DEBUGGING"
+                } else {
+                    ""
+                },
             );
             use std::io::Write;
             let mut uvc_internal =

--- a/uvc-sys/Cargo.toml
+++ b/uvc-sys/Cargo.toml
@@ -12,9 +12,10 @@ edition = "2018"
 
 [features]
 vendor = ["uvc-src"]
+uvc_debugging = ["uvc-src/uvc_debugging"]
 
 [dependencies]
 uvc-src = { path = "../uvc-src", version = "0.2.2", optional = true, features = ["jpeg"] }
 
 [build-dependencies]
-bindgen = "0.56.0"
+bindgen = "0.64.0"

--- a/uvc-sys/Cargo.toml
+++ b/uvc-sys/Cargo.toml
@@ -1,21 +1,21 @@
 [package]
 name = "uvc-sys"
 description = "Raw wrapper of libuvc"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Magnus Ulimoen <flymagnus@gmail.com>"]
 links = "uvc"
 build = "build.rs"
 license = "MIT"
 repository = "https://github.com/mulimoen/libuvc-rs.git"
 categories = ["external-ffi-bindings", "multimedia::video"]
-edition = "2018"
+edition = "2021"
 
 [features]
 vendor = ["uvc-src"]
 uvc_debugging = ["uvc-src/uvc_debugging"]
 
 [dependencies]
-uvc-src = { path = "../uvc-src", version = "0.2.2", optional = true, features = ["jpeg"] }
+uvc-src = { path = "../uvc-src", version = "0.3.0", optional = true, features = ["jpeg"] }
 
 [build-dependencies]
 bindgen = "0.64.0"

--- a/uvc-sys/Cargo.toml
+++ b/uvc-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "uvc-sys"
 description = "Raw wrapper of libuvc"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Magnus Ulimoen <flymagnus@gmail.com>"]
 links = "uvc"
 build = "build.rs"
@@ -14,7 +14,7 @@ edition = "2018"
 vendor = ["uvc-src"]
 
 [dependencies]
-uvc-src = { path = "../uvc-src", version = "0.2.1", optional = true, features = ["jpeg"] }
+uvc-src = { path = "../uvc-src", version = "0.2.2", optional = true, features = ["jpeg"] }
 
 [build-dependencies]
 bindgen = "0.56.0"

--- a/uvc-sys/build.rs
+++ b/uvc-sys/build.rs
@@ -22,8 +22,8 @@ fn main() {
 
     let bindings = builder
         .header("wrapper.h")
-        .whitelist_function("uvc_.*")
-        .whitelist_type("uvc_.*")
+        .allowlist_function("uvc_.*")
+        .allowlist_type("uvc_.*")
         .generate()
         .expect("Failed to generate bindings");
 


### PR DESCRIPTION
A bit of a conglomerate PR: 
* Latest version of UVC upstream, mainly to squelch "usbfs: process 7154 (blah) did not claim interface 0 before use"
* add build feature uvc_debugging to build uvc with "#define UVC_DEBUGGING"
* Latest version of bindgen to squelch "warning: the following packages contain code that will be rejected by a future version of Rust: nom v5.1.2"